### PR TITLE
Added change log to ease upgrading between versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,55 @@
+# Change Log
+
+## 0.2.7
+- Feature: Added a debug prop to `<LionessProvider>`
+
+## 0.2.6
+- Feature: Export interpolateComponents
+
+## 0.2.5
+- Breaking: Rename tpn -> tnp and tcpn -> tcnp
+- Breaking: Dropped official support for node.js 5 and 7
+- Feature: Added official support for node.js 8
+- Feature: Set displayName when using `withTranslators()`
+- Chore: Improved documentation
+
+## 0.2.4
+- Feature: Added support for gettext text domains
+
+## 0.2.3
+- Bug: Fixed proptypes notices
+- Chore: Improved documentation
+
+## 0.2.2
+- Feature: Handled interpolation of non-string, non-element scope variables
+
+## 0.2.1
+- Bug: Makes logo image URL a full path
+
+## 0.2.0
+- Breaking: Rename composers.js -> withTranslators.js
+- Breaking: Rename gettext.js -> getGettextInstance.js
+- Breaking: Extract `interpolateComponents()` into a separate file
+- Feature: Added tc, tcn, tcp, tcpn translators
+- Feature: `interpolateComponents()` now returns simple string if it can
+- Chore: Added tests and CI
+
+## 0.1.5
+- Bug: Fixes bad parsing of key/value commas in interpolated variables
+
+## 0.1.4
+- Feature: Allows commas to be used in interpolated scope values
+
+## 0.1.3
+- Feature: Improve interpolation regex to allow whatever inside curly braces
+
+## 0.1.2
+- Bug: Fixed image path
+
+## 0.1.1
+- Breaking: Change package name to lioness
+- Feature: Defines prop types on `<T>`
+- Chore: Removes unused interpolate package dependency
+
+## 0.1.0
+- Initial release


### PR DESCRIPTION
I think it's important to have a change log as when it comes to upgrading it's not clear what's changed between releases. I know it does add additional overhead to the release process but I think it's well worth it if more people are going to use lioness - worse case scenario we can go back and update it.

I'm open to different conventions but in particular I wanted to highlight breaking changes, bew features and bug fixes. Anything that doesn't help a user of this library e.g. linting is not worth mentioning.