### PR TITLE
Enables locale and translation updates on-the-fly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3092,11 +3092,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        },
         "string-width": {
           "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
@@ -3106,6 +3101,11 @@
             "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
             "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
           }
+        },
+        "string_decoder": {
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
         },
         "stringstream": {
           "version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
@@ -5528,15 +5528,6 @@
       "integrity": "sha1-GsWtaDJCjKVWZ9ve45Xa1ObbEY8=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-      "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.0"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -5546,6 +5537,15 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+      "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.0"
       }
     },
     "stringify-object": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "scripts": {
     "lint": "eslint src",
-    "test": "mocha --compilers js:babel-core/register tests/helpers/browser.js tests/{.,components}/*.js",
+    "test": "mocha --compilers js:babel-core/register tests/helpers/browser.js tests/{.,components,integration-tests}/*.js",
     "prebuild": "rimraf dist",
     "build": "babel --out-dir dist src",
     "example": "cd examples && webpack-dev-server --port 8111"

--- a/src/components/LionessProvider.js
+++ b/src/components/LionessProvider.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 
 import getGettextInstance from '../getGettextInstance.js'
 import * as contextTypes from '../contextTypes.js'
+import { emit } from '../pubsub.js'
 import { t, tn, tp, tnp, tc, tcn, tcp, tcnp } from '../translators.js'
 import interpolateComponents from '../interpolateComponents.js'
 
@@ -35,6 +36,15 @@ class LionessProvider extends Component {
       ? {}
       : { debug: props.debug }
     this.gt = getGettextInstance(props.messages, props.locale, options)
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.locale !== this.props.locale) {
+      emit()
+    }
+    if (prevProps.messages !== this.props.messages) {
+      emit()
+    }
   }
 
   /**

--- a/src/forceUpdatedComponent.js
+++ b/src/forceUpdatedComponent.js
@@ -1,0 +1,41 @@
+import React, { PureComponent } from 'react'
+import { wrapDisplayName } from 'recompose'
+
+import { subscribe, unsubscribe } from './pubsub.js'
+
+/**
+ * Returns a HOC that triggers a re-render of itself whenever
+ * a subscription notification is received.
+ */
+export default function forceUpdatedComponent(InputComponent) {
+  class SubscribeUpdater extends PureComponent {
+    constructor(props) {
+      super(props)
+
+      this.state = {
+        lastNotification: null,
+      }
+    }
+
+    componentDidMount() {
+      subscribe(this.handleNotification.bind(this))
+    }
+
+    componentWillUnmount() {
+      unsubscribe(this.handleNotification)
+    }
+
+    handleNotification() {
+      this.setState({
+        lastNotification: Date.now(),
+      })
+    }
+
+    render() {
+      return <InputComponent {...this.props} />
+    }
+  }
+
+  SubscribeUpdater.displayName = wrapDisplayName(InputComponent, 'forceUpdatedComponent')
+  return SubscribeUpdater
+}

--- a/src/forceUpdatedComponent.js
+++ b/src/forceUpdatedComponent.js
@@ -9,23 +9,19 @@ import { subscribe, unsubscribe } from './pubsub.js'
  */
 export default function forceUpdatedComponent(InputComponent) {
   class SubscribeUpdater extends PureComponent {
-    constructor(props) {
-      super(props)
-
-      this.state = {
-        lastNotification: null,
-      }
+    state = {
+      lastNotification: null,
     }
 
     componentDidMount() {
-      subscribe(this.handleNotification.bind(this))
+      subscribe(this.handleNotification)
     }
 
     componentWillUnmount() {
       unsubscribe(this.handleNotification)
     }
 
-    handleNotification() {
+    handleNotification = () => {
       this.setState({
         lastNotification: Date.now(),
       })

--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -1,0 +1,13 @@
+let subscribers = []
+
+export const subscribe = fn => {
+  subscribers = [...subscribers, fn]
+}
+
+export const unsubscribe = fn => {
+  subscribers = subscribers.filter(x => x !== fn)
+}
+
+export const emit = () => {
+  subscribers.forEach(fn => fn())
+}

--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -1,7 +1,7 @@
 let subscribers = []
 
 export const subscribe = fn => {
-  if (subscribers.includes(fn) === false) {
+  if (subscribers.indexOf(fn) === -1) {
     subscribers = [...subscribers, fn]
   }
 }

--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -1,7 +1,9 @@
 let subscribers = []
 
 export const subscribe = fn => {
-  subscribers = [...subscribers, fn]
+  if (subscribers.includes(fn) === false) {
+    subscribers = [...subscribers, fn]
+  }
 }
 
 export const unsubscribe = fn => {

--- a/src/withTranslators.js
+++ b/src/withTranslators.js
@@ -1,13 +1,15 @@
 import { getContext, wrapDisplayName } from 'recompose'
 
 import * as contextTypes from './contextTypes.js'
+import forceUpdatedComponent from './forceUpdatedComponent.js'
 
 /**
  * Provides the given component with translator functions
  * as props.
  */
 export default function withTranslators(WrappedComponent) {
-  const withTranslators = getContext(contextTypes)(WrappedComponent)
+  const forceUpdatedWrappedComponent = forceUpdatedComponent(WrappedComponent)
+  const withTranslators = getContext(contextTypes)(forceUpdatedWrappedComponent)
   withTranslators.displayName = wrapDisplayName(WrappedComponent, 'withTranslators')
   return withTranslators
 }

--- a/tests/components/LionessProvider-test.js
+++ b/tests/components/LionessProvider-test.js
@@ -5,11 +5,12 @@ import React from 'react'
 import chai, { expect } from 'chai'
 import chaiEnzyme from 'chai-enzyme'
 import { mount } from 'enzyme'
-import { spy } from 'sinon'
+import { spy, stub } from 'sinon'
 import Gettext from 'node-gettext'
 
 import LionessProvider from '../../src/components/LionessProvider.js'
 import * as gti from '../../src/getGettextInstance.js'
+import * as pubsub from '../../src/pubsub.js'
 import withTranslators from '../../src/withTranslators.js'
 
 chai.use(chaiEnzyme())
@@ -88,5 +89,20 @@ describe('<LionessProvider />', () => {
   it('provides all translators through its child context', () => {
     const consumer = provider.find(ContextConsumer)
     expect(consumer.node.context).to.contain.all.keys(['t', 'tn', 'tp', 'tnp', 'tc', 'tcn', 'tcp', 'tcnp'])
+  })
+
+  it('calls the pubsub emit() function whenever the `locale` or `messages` props change', () => {
+    const emitStub = stub(pubsub, 'emit')
+
+    provider.setProps({ locale: 'sv-SE' })
+    expect(emitStub.callCount).to.equal(1)
+
+    provider.setProps({ messages: { ...MESSAGES } })
+    expect(emitStub.callCount).to.equal(2)
+
+    provider.setProps({ debug: true })
+    expect(emitStub.callCount).to.equal(2)
+
+    emitStub.restore()
   })
 })

--- a/tests/components/T-test.js
+++ b/tests/components/T-test.js
@@ -17,20 +17,24 @@ const identity = x => x
 // Translation fixtures
 const MESSAGES = {
   'en': {
+    charset: 'utf-8',
+    headers: {},
     'translations': {
       '': {
         'hi there': {
-          'msid': 'hi there',
+          'msgid': 'hi there',
           'msgstr': 'hi there',
         },
       },
     },
   },
   'sv-SE': {
+    charset: 'utf-8',
+    headers: {},
     'translations': {
       '': {
         'hi there': {
-          'msid': 'hi there',
+          'msgid': 'hi there',
           'msgstr': 'hallå där',
         },
       },

--- a/tests/forceUpdatedComponent-test.js
+++ b/tests/forceUpdatedComponent-test.js
@@ -1,0 +1,74 @@
+/* eslint-env mocha */
+
+import React from 'react'
+import { describe, it } from 'mocha'
+import chai, { expect } from 'chai'
+import chaiEnzyme from 'chai-enzyme'
+import { stub } from 'sinon'
+import { mount } from 'enzyme'
+
+import forceUpdatedComponent from '../src/forceUpdatedComponent.js'
+import * as pubsub from '../src/pubsub.js'
+
+chai.use(chaiEnzyme())
+
+const Thingy = () => <div>Thingy</div>
+
+describe('forceUpdatedComponent()', () => {
+  let ForceUpdatedThingy
+  let subscribeStub
+  let unsubscribeStub
+
+  beforeEach(() => {
+    ForceUpdatedThingy = forceUpdatedComponent(Thingy)
+    subscribeStub = stub(pubsub, 'subscribe')
+    unsubscribeStub = stub(pubsub, 'unsubscribe')
+  })
+
+  afterEach(() => {
+    subscribeStub.restore()
+    unsubscribeStub.restore()
+  })
+
+  it('renders the passed component', () => {
+    const app = mount(<ForceUpdatedThingy />)
+    expect(app.find(Thingy)).to.have.length(1)
+  })
+
+  it('passes on all props to the passed component', () => {
+    const props = {
+      count: 1619,
+      moritz: 'Von Oswald',
+      wow: 'This is not bad',
+    }
+    const appWithProps = mount(<ForceUpdatedThingy {...props} />)
+
+    expect(appWithProps.find(Thingy).props()).to.deep.equal(props)
+  })
+
+  it('subscribes its handleNotification function via subscribe()', () => {
+    mount(<ForceUpdatedThingy />)
+    expect(subscribeStub.callCount).to.equal(1)
+  })
+
+  it('unsubscribes its handleNotification function using unsubscribe()', () => {
+    const app = mount(<ForceUpdatedThingy />)
+    app.unmount()
+    expect(unsubscribeStub.callCount).to.equal(1)
+  })
+
+  it('updates the lastNotification state value when handleNotification is called', (done) => {
+    const app = mount(<ForceUpdatedThingy />)
+    expect(app.state().lastNotification).to.equal(null)
+
+    app.node.handleNotification()
+    const notification1 = app.state().lastNotification
+    expect(notification1).to.be.above(0)
+
+    setTimeout(() => {
+      app.node.handleNotification()
+      expect(app.state().lastNotification).to.be.above(notification1)
+      done()
+    }, 10)
+  })
+})

--- a/tests/integration-tests/context-updates.js
+++ b/tests/integration-tests/context-updates.js
@@ -1,0 +1,43 @@
+/* eslint-env mocha */
+
+import React from 'react'
+import { describe, it } from 'mocha'
+import chai, { expect } from 'chai'
+import chaiEnzyme from 'chai-enzyme'
+import { mount } from 'enzyme'
+import { shouldUpdate } from 'recompose'
+
+import LionessProvider from '../../src/components/LionessProvider.js'
+import T from '../../src/components/T.js'
+
+chai.use(chaiEnzyme())
+
+const MESSAGES = {
+  'en': {},
+  'sv-SE': {},
+}
+
+const Parent = ({ children }) => <div>{children}</div>
+const FreezedParent = shouldUpdate(() => false)(Parent)
+
+describe('Context updates', () => {
+  it('forces <T> to re-render when <LionessProvider> gets a new locale or dictionary', () => {
+    const app = mount(
+      <LionessProvider messages={MESSAGES} locale="en">
+        <FreezedParent>
+          <T message="wow" />
+        </FreezedParent>
+      </LionessProvider>
+    )
+
+    const t = app.find(T)
+    expect(t.parent().props().locale).to.equal('en')
+
+    app.setProps({ locale: 'sv-SE' })
+    expect(t.parent().props().locale).to.equal('sv-SE')
+
+    const newMessages = { ...MESSAGES }
+    app.setProps({ messages: newMessages })
+    expect(t.parent().props().messages).to.deep.equal(newMessages)
+  })
+})

--- a/tests/pubsub-test.js
+++ b/tests/pubsub-test.js
@@ -23,4 +23,39 @@ describe('subscribe() and unsubscribe()', () => {
     emit()
     expect(fn.callCount).to.equal(2)
   })
+
+  it('notifies the right subscribers in a group of subscribers', () => {
+    const fn1 = spy()
+    const fn2 = spy()
+    const fn3 = spy()
+
+    subscribe(fn1)
+    subscribe(fn2)
+    emit()
+    expect(fn1.callCount).to.equal(1)
+    expect(fn2.callCount).to.equal(1)
+    expect(fn3.callCount).to.equal(0)
+
+    subscribe(fn3)
+    unsubscribe(fn1)
+    emit()
+    expect(fn1.callCount).to.equal(1)
+    expect(fn2.callCount).to.equal(2)
+    expect(fn3.callCount).to.equal(1)
+
+    unsubscribe(fn2)
+    emit()
+    expect(fn1.callCount).to.equal(1)
+    expect(fn2.callCount).to.equal(2)
+    expect(fn3.callCount).to.equal(2)
+  })
+
+  it('subscribes a function only once', () => {
+    const fn = spy()
+
+    subscribe(fn)
+    subscribe(fn)
+    emit()
+    expect(fn.callCount).to.equal(1)
+  })
 })

--- a/tests/pubsub-test.js
+++ b/tests/pubsub-test.js
@@ -1,0 +1,26 @@
+/* eslint-env mocha */
+
+import { describe, it } from 'mocha'
+import { expect } from 'chai'
+import { spy } from 'sinon'
+
+import { emit, subscribe, unsubscribe } from '../src/pubsub.js'
+
+describe('subscribe() and unsubscribe()', () => {
+  it('registers and invokes a function passed to subscribe() when emit() is called', () => {
+    const fn = spy()
+
+    emit()
+    expect(fn.called).to.equal(false)
+
+    subscribe(fn)
+    emit()
+    expect(fn.callCount).to.equal(1)
+    emit()
+    expect(fn.callCount).to.equal(2)
+
+    unsubscribe(fn)
+    emit()
+    expect(fn.callCount).to.equal(2)
+  })
+})


### PR DESCRIPTION
Forces updates to `<T>` components when `<LionessProvider>` gets new `locale` or `messages` props. This makes it possible to change the locale and translations on-the-fly and have the UI update. (Changing values of contexts does not trigger updates.)