### PR TITLE
Adds string interpolation support to t(), tn(), tp() and tnp()

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,49 +187,54 @@ The following table indicates how gettext strings map to parameters in `withTran
 | msgid_plural | other | messagePlural |
 
 
-### withTranslations
+### `withTranslations(Component)`
 
-| Letter | Meaning | Parameter
+Provides `Component` with the `lioness` context variables as props. These are `locale`, `t`, `tn`, `tp`, `tnp`, `tc`, `tcn`, `tcp` and `tcnp`.
+
+As a little helper, here's what the letters stand for:
+
+| Letter | Meaning | Parameters
 | --- | --- | --- |
-| t | string to translate | message |
-| c | interpolate string | scope |
-| n | string is plural | one, other, count |
-| p | context as used in gettext | context |
+| t | translate a message | `message` |
+| c | ...with injected React components | - |
+| n | ...with pluralisation | `one`, `other`, `count` |
+| p | ...in a certain gettext context | `context` |
 
+* #### `locale`
 
+  The currently set locale passed to `<LionessProvider />`.
 
-#### t(message)
+* #### `t(message, scope = {})`
 
-Translate a message
+  Translates and interpolates message.
 
-#### tn(one, other, count)
+* #### `tn(one, other, count, scope = {})`
 
-Translate a plural message
+  Translates and interpolates a pluralised message.
 
-#### tp(context, message)
+* #### `tp(context, message, scope = {})`
 
-Translate a message and context
+  Translates and interpolates a message in a given context.
 
-#### tnp(context, one, other, count)
+* #### `tnp(context, one, other, count, scope = {})`
 
-Translate a plural message with context
+  Translates and interpolates a pluralised message in a given context.
 
+* #### `tc(message, scope = {})`
 
-#### tc(message, scope = {})
+  Translates and interpolates a message.
 
-Translate a message with variable interpolate
+* #### `tcn(one, other, count, scope = {})`
 
-#### tcn(one, other, count, scope)
+  Translates and interpolates a pluralised message.
 
-Translate a plural message with variable interpolate
+* #### `tcp(context, message, scope = {})`
 
-#### tcp(context, message, scope)
+  Translates and interpolates a message in a given context.
 
-Translate a message with context and variable interpolate
+* #### `tcnp(context, one, other, count, scope = {})`
 
-#### tcnp(context, one, other, count, scope)
-
-Translate a plural message with context and variable interpolate
+  Translates and interpolates a plural message in a given context.
 
 
 

--- a/examples/src/app.js
+++ b/examples/src/app.js
@@ -85,12 +85,12 @@ let MyThing = ({ t, message }) =>
 MyThing = withTranslators(MyThing);
 
 // Singular/plural
-const Diff = withTranslators(({ tn, num }) => (
+const Diff = withTranslators(({ tcn, num }) => (
   <div>
-    {tn('{{ one:One }} thing ({{ link:Add more }})', '{{ count }} things', num, {
+    {tcn('{{ one:One }} thing ({{ link:Add more }})', '{{ num }} things', num, {
       one: <em />,
-      count: <strong>{num}</strong>,
       link: <a href="#add-more" />,
+      num: num,
     })}
   </div>
 ));
@@ -98,6 +98,13 @@ const Diff = withTranslators(({ tn, num }) => (
 // A clickable number
 const ClickableNumber = () =>
   <em onClick={() => alert('click')} style={{ cursor: 'pointer' }}>131</em>;
+
+// A pure interpolated string
+const HoverableItemWithNumber = withTranslators(({ t, itemNumber }) => (
+  <div title={t('This is item number {{ itemNumber }}', { itemNumber })}>
+    Hover me to see my number
+  </div>
+))
 
 /**
  * Example app
@@ -117,12 +124,12 @@ const App = () =>
       <MyThing message="Close" />
 
       <hr />
-      <pre>{`const Diff = withTranslators(({ tn, num }) => (
+      <pre>{`const Diff = withTranslators(({ tcn, num }) => (
   <div>
-    {tn('{{ one:One }} thing ({{ link:Add more }})', '{{ count }} things', num, {
+    {tcn('{{ one:One }} thing ({{ link:Add more }})', '{{ num }} things', num, {
       one: <em />,
-      count: <strong>{num}</strong>,
       link: <a href="#add-more" />,
+      num: num,
     })}
   </div>
 ));
@@ -133,6 +140,18 @@ const App = () =>
 <Diff num={2} />`}</pre>
       <Diff num={1} />
       <Diff num={2} />
+
+      <hr />
+      <pre>{`const HoverableItemWithNumber = withTranslators(({ t, itemNumber }) => (
+  <div title={t('This is item number {{ itemNumber }}', { itemNumber })}>
+    Hover me to see my number
+  </div>
+))
+
+<HoverableItemWithNumber itemNumber={1} />
+<HoverableItemWithNumber itemNumber={2} />`}</pre>
+      <HoverableItemWithNumber itemNumber={1} />
+      <HoverableItemWithNumber itemNumber={2} />
     </div>
   </LionessProvider>;
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "lint": "eslint src",
     "test": "mocha --compilers js:babel-core/register tests/helpers/browser.js tests/{.,components,integration-tests}/*.js",
+    "test-file": "mocha --compilers js:babel-core/register tests/helpers/browser.js",
     "prebuild": "rimraf dist",
     "build": "babel --out-dir dist src",
     "example": "cd examples && webpack-dev-server --port 8111"

--- a/src/components/LionessProvider.js
+++ b/src/components/LionessProvider.js
@@ -5,7 +5,6 @@ import getGettextInstance from '../getGettextInstance.js'
 import * as contextTypes from '../contextTypes.js'
 import { emit } from '../pubsub.js'
 import { t, tn, tp, tnp, tc, tcn, tcp, tcnp } from '../translators.js'
-import interpolateComponents from '../interpolateComponents.js'
 
 /**
  * Localization context provider
@@ -58,10 +57,10 @@ class LionessProvider extends Component {
       tn: tn(this.gt.ngettext.bind(this.gt)),
       tp: tp(this.gt.pgettext.bind(this.gt)),
       tnp: tnp(this.gt.npgettext.bind(this.gt)),
-      tc: tc(interpolateComponents, this.gt.gettext.bind(this.gt)),
-      tcn: tcn(interpolateComponents, this.gt.ngettext.bind(this.gt)),
-      tcp: tcp(interpolateComponents, this.gt.pgettext.bind(this.gt)),
-      tcnp: tcnp(interpolateComponents, this.gt.npgettext.bind(this.gt)),
+      tc: tc(this.gt.gettext.bind(this.gt)),
+      tcn: tcn(this.gt.ngettext.bind(this.gt)),
+      tcp: tcp(this.gt.pgettext.bind(this.gt)),
+      tcnp: tcnp(this.gt.npgettext.bind(this.gt)),
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,11 +2,12 @@ import LionessProvider from './components/LionessProvider.js'
 import T from './components/T.js'
 import withTranslators from './withTranslators.js'
 
-import { interpolateComponents } from './interpolateComponents.js'
+import { interpolateComponents, interpolateString } from './interpolators.js'
 
 export {
   LionessProvider,
   T,
   withTranslators,
   interpolateComponents,
+  interpolateString,
 }

--- a/src/interpolators.js
+++ b/src/interpolators.js
@@ -10,14 +10,16 @@ import React from 'react'
 
 */
 
-export default interpolateComponents
-
 // Note that [^] is used rather than . to match any character. This
 // is because . doesn't span over multiple lines, whereas [^] does.
 const variableRegex = /(\{\{\s[^]+?(?=\s\}\})\s\}\})/g
 
 /**
- * Returns whether a string is a template variable
+ * Returns whether a string is a template variable.
+ *
+ * @param  {String}    str  A string
+ * @return {Boolean}        True if the string is a template variable,
+ *                          false if not
  */
 export function isTemplateVariable(str) {
   return new RegExp(variableRegex).test(str)
@@ -27,7 +29,48 @@ export function isTemplateVariable(str) {
  * Interpolates a string, replacing template variables with values
  * provided in the scope.
  *
- * Besides replacing variables with
+ * @param  {String}    str    A string to be interpolated
+ * @param  {Object}    scope  An object with variable names and their
+ *                            replacements
+ * @return {String}           An interpolated string
+ */
+export function interpolateString(str, scope = {}) {
+  if (!str) {
+    return str
+  }
+
+  // Split string into array with regular text and variables split
+  // into separate segments, like ['This is a ', '{{ thing }}', '!']
+  const parts = str.split(new RegExp(variableRegex)).filter(x => x)
+
+  // If the only thing we have is a single regular string, just return it as is
+  if (parts.length === 1 && isTemplateVariable(parts[0]) === false) {
+    return str
+  }
+
+  return parts
+    .map(part => {
+      if (isTemplateVariable(part) === false) {
+        return part
+      }
+
+      const variableName = part.replace(/^\{\{\s/, '').replace(/\s\}\}$/, '')
+      if (scope[variableName] === undefined) {
+        return part
+      }
+
+      return scope[variableName]
+    })
+    .join('')
+}
+
+/**
+ * Interpolates a string, with support for injecting React components.
+ *
+ * @param  {String}    str    A string to be interpolated
+ * @param  {Object}    scope  An object with variable names and their
+ *                            replacements
+ * @return {Component}        A React component
  */
 export function interpolateComponents(str, scope = {}) {
   if (!str) {

--- a/src/translators.js
+++ b/src/translators.js
@@ -1,24 +1,29 @@
 import curry from 'lodash.curry'
 
-export const tc = curry((interpolate, translate, message, scope = {}) => {
+import { interpolateComponents, interpolateString } from './interpolators.js'
+
+export const ti = curry((interpolate, translate, message, scope = {}) => {
   return interpolate(translate(message), scope)
 })
 
-export const tcn = curry((interpolate, translate, one, other, count, scope = {}) => {
+export const tin = curry((interpolate, translate, one, other, count, scope = {}) => {
   return interpolate(translate(one, other, count), scope)
 })
 
-export const tcp = curry((interpolate, translate, context, message, scope = {}) => {
+export const tip = curry((interpolate, translate, context, message, scope = {}) => {
   return interpolate(translate(context, message), scope)
 })
 
-export const tcnp = curry((interpolate, translate, context, one, other, count, scope = {}) => {
+export const tinp = curry((interpolate, translate, context, one, other, count, scope = {}) => {
   return interpolate(translate(context, one, other, count), scope)
 })
 
-const identity = x => x
+export const t = ti(interpolateString)
+export const tn = tin(interpolateString)
+export const tp = tip(interpolateString)
+export const tnp = tinp(interpolateString)
 
-export const t = tc(identity)
-export const tn = tcn(identity)
-export const tp = tcp(identity)
-export const tnp = tcnp(identity)
+export const tc = ti(interpolateComponents)
+export const tcn = tin(interpolateComponents)
+export const tcp = tip(interpolateComponents)
+export const tcnp = tinp(interpolateComponents)

--- a/tests/translators-test.js
+++ b/tests/translators-test.js
@@ -1,73 +1,58 @@
 /* eslint-env mocha */
 
 import { expect } from 'chai'
-import { spy, stub } from 'sinon'
+import { stub } from 'sinon'
 
-import { t, tp, tn, tnp, tc, tcp, tcn, tcnp } from '../src/translators.js'
+import { ti, tin, tip, tinp } from '../src/translators.js'
 
 describe('translators', () => {
-  let interpolate
-  let translate
   const scope = { name: 'francesca' }
 
-  beforeEach(() => {
-    interpolate = spy()
-    translate = stub().returns('groundhog day')
+  it('apply the provided interpolate function', () => {
+    const interpolate = stub()
+    const translateIntoNumber = stub()
+    translateIntoNumber.onCall(0).returns('0')
+    translateIntoNumber.onCall(1).returns('1')
+    translateIntoNumber.onCall(2).returns('2')
+    translateIntoNumber.onCall(3).returns('3')
+
+    const t1 = ti(interpolate)
+    const t2 = tin(interpolate)
+    const t3 = tip(interpolate)
+    const t4 = tinp(interpolate)
+
+    t1(translateIntoNumber, 'wow', scope)
+    t2(translateIntoNumber, 'wow', 'wows', 10, scope)
+    t3(translateIntoNumber, 'universe', 'wow', scope)
+    t4(translateIntoNumber, 'universe', 'wow', 'wows', 10, scope)
+
+    expect(interpolate.callCount).to.equal(4)
+    expect(interpolate.args[0]).to.deep.equal(['0', scope])
+    expect(interpolate.args[1]).to.deep.equal(['1', scope])
+    expect(interpolate.args[2]).to.deep.equal(['2', scope])
+    expect(interpolate.args[3]).to.deep.equal(['3', scope])
   })
 
-  describe('t()', () => {
-    it('translates the message using the provided translate function', () => {
-      t(translate, 'wow')
-      expect(translate.calledWithMatch('wow')).to.equal(true)
-    })
-  })
+  it('apply the provided translate functions', () => {
+    const interpolate = stub()
+    const translate1 = stub()
+    const translate2 = stub()
+    const translate3 = stub()
+    const translate4 = stub()
 
-  describe('tc()', () => {
-    it('interpolates the translated string with the provided scope', () => {
-      tc(interpolate, translate, 'wow', scope)
-      expect(interpolate.calledWithMatch('groundhog day', scope)).to.equal(true)
-    })
-  })
+    const t1 = ti(interpolate, translate1)
+    const t2 = tin(interpolate, translate2)
+    const t3 = tip(interpolate, translate3)
+    const t4 = tinp(interpolate, translate4)
 
-  describe('tn()', () => {
-    it('translates the message using the provided translate function', () => {
-      tn(translate, 'wow', 'wows', 12)
-      expect(translate.calledWithMatch('wow', 'wows', 12)).to.equal(true)
-    })
-  })
+    t1('wow', scope)
+    t2('wow', 'wows', 10, scope)
+    t3('universe', 'wow', scope)
+    t4('universe', 'wow', 'wows', 10, scope)
 
-  describe('tcn()', () => {
-    it('interpolates the translated string with the provided scope', () => {
-      tcn(interpolate, translate, 'wow', 'wows', 12, scope)
-      expect(interpolate.calledWithMatch('groundhog day', scope)).to.equal(true)
-    })
-  })
-
-  describe('tp()', () => {
-    it('translates the message using the provided translate function', () => {
-      tp(translate, 'context', 'wow')
-      expect(translate.calledWithMatch('context', 'wow')).to.equal(true)
-    })
-  })
-
-  describe('tcp()', () => {
-    it('interpolates the translated string with the provided scope', () => {
-      tcp(interpolate, translate, 'context', 'wow', scope)
-      expect(interpolate.calledWithMatch('groundhog day', scope)).to.equal(true)
-    })
-  })
-
-  describe('tnp()', () => {
-    it('translates the message using the provided translate function', () => {
-      tnp(translate, 'context', 'wow', 'wows', 1)
-      expect(translate.calledWithMatch('context', 'wow', 'wows', 1)).to.equal(true)
-    })
-  })
-
-  describe('tcnp()', () => {
-    it('interpolates the translated string with the provided scope', () => {
-      tcnp(interpolate, translate, 'context', 'wow', 'wows', 1, scope)
-      expect(interpolate.calledWithMatch('groundhog day', scope)).to.equal(true)
-    })
+    expect(translate1.args[0]).to.deep.equal(['wow'])
+    expect(translate2.args[0]).to.deep.equal(['wow', 'wows', 10])
+    expect(translate3.args[0]).to.deep.equal(['universe', 'wow'])
+    expect(translate4.args[0]).to.deep.equal(['universe', 'wow', 'wows', 10])
   })
 })


### PR DESCRIPTION
Addressing #10 by enabling string interpolation in non-component translators like so:

```js
t('Hi, my name is {{ name }}', { name: 'Slim Shady' })
// => "Hi, my name is Slim Shady"

tn(
  'I wanna dance with somebody (who loves me)',
  'I wanna dance with {{ numPeople }} people (who love me)',
  10,
  { numPeople: 10 }
)
// => "I wanna dance with 10 people (who love me)"

tp(
  'the jam',
  'Pump {{ thing }} up',
  { thing: 'it' }
)
// => "Pump it up" (in the "the jam" gettext context)

tnp(
  'freestyler',
  'Rock the microphone',
  'Rock {{ numMics }} microphones',
  numMics,
  { numMics: 1 }
)
// => "Rock the microphone" (in the "freestyler" context)
```