### PR TITLE
Added withTranslators HOC type export to index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -33,6 +33,10 @@ declare module 'lioness' {
     ): string
   }
 
+  export const withTranslators: <T>(
+    component: React.ComponentType<T & WithTranslators>,
+  ) => React.ComponentType<T>;
+
   namespace T {
     export interface Props {
       message: string


### PR DESCRIPTION
@alexanderwallin Sorry, I missed `withTranslators` HOC type in the previous PR.