### PR TITLE
Update React version in peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "homepage": "https://github.com/alexanderwallin/lioness-react#readme",
   "peerDependencies": {
     "prop-types": "^15.5.8",
-    "react": "^15.0.0"
+    "react": "^15.0.0 || ^16.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",


### PR DESCRIPTION
This library is fully working in React 16.

So I've updated the `peerDependencies` to include it.