### PR TITLE
Drop support for Node.js 4/6 and add support 10/12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
+  - "12"
+  - "10"
   - "8"
-  - "6"
-  - "4"
 before_install:
   - if [[ `npm -v` != 5* ]]; then npm i -g npm@5; fi
 install:


### PR DESCRIPTION
Node.js 4 and 6 are end of life and are no longer supported. We should drop them from the support matrix and add the newer versions. This will allow CI to pass again since when we upgraded Mocha in 7421e5a from ^3.2.0 to ^6.2.0 it dropped support for node.js 4.x and 6.x